### PR TITLE
Add JSON export helpers

### DIFF
--- a/src/bind/solution/solution.cpp
+++ b/src/bind/solution/solution.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <string>
+#include <sstream>
 
 #include "structures/vroom/solution/solution.cpp"
 
@@ -22,6 +23,21 @@ struct _Step{
 
   char description[40];
 };
+
+static std::string solution_to_json(const vroom::Solution& solution) {
+  std::ostringstream oss;
+  oss << "{";
+  oss << "\"code\":" << solution.code;
+  if (!solution.error.empty()) {
+    oss << ",\"error\":\"" << solution.error << "\"";
+  }
+  oss << ",\"summary\":{"
+      << "\"cost\":" << solution.summary.cost << ","
+      << "\"routes\":" << solution.summary.routes << ","
+      << "\"unassigned\":" << solution.summary.unassigned << "}";
+  oss << "}";
+  return oss.str();
+}
 
 
 void init_solution(py::module_ &m){
@@ -80,6 +96,7 @@ void init_solution(py::module_ &m){
       }
       return arr;
     })
+    .def("_to_json", &solution_to_json)
     .def_readwrite("code", &vroom::Solution::code)
     .def_readwrite("error", &vroom::Solution::error)
     .def_readonly("summary", &vroom::Solution::summary)

--- a/src/vroom/solution/solution.py
+++ b/src/vroom/solution/solution.py
@@ -37,3 +37,12 @@ class Solution(_vroom.Solution):
             else:
                 frame.loc[frame[column] == NA_SUBSTITUTE, column] = pandas.NA
         return frame
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the solution as a Python dictionary."""
+        return json.loads(self._to_json())
+
+    def to_file(self, path: str) -> None:
+        """Write the solution JSON representation to *path*."""
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(self._to_json())


### PR DESCRIPTION
## Summary
- expose a `_to_json` binding for `Solution`
- wrap helper methods in `Solution.to_dict` and `Solution.to_file`

## Testing
- `pytest -q` *(fails: command not found)*
- `make test` *(fails: coverage: No such file or directory)*